### PR TITLE
Adding exception handling when a response is HTML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ doc/
 
 .DS_Store
 Gemfile.lock
+*.swp
+.rvmrc

--- a/lib/requests/client.rb
+++ b/lib/requests/client.rb
@@ -40,7 +40,12 @@ module Change
         when 200, 202
           response.parsed_response
         else
-          messages = response.parsed_response['messages']
+          messages = if response.code == 500
+            ['A server error has occurred.']
+          else
+            response.parsed_response['messages']
+          end
+
           raise ChangeException.new(messages, response.code), messages.join(' '), caller
         end
       end
@@ -71,5 +76,5 @@ module Change
       end
 
     end
-  end  
+  end
 end

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -56,6 +56,16 @@ describe 'Client' do
       lambda { @petition.load(1) }.must_raise(Change::Exceptions::ChangeException)
     end
 
+    it "should raise an exception if the response is a server error" do
+      url_to_be_called = 'https://api.change.org/v1/petitions/1'
+      params = { :api_key => @api_key_example }
+      @client.expects(:send)
+        .with('get', url_to_be_called, params)
+        .once
+        .returns(MockResponse.new(500, "<html>You broke me!</html>"))
+      lambda { @petition.load(1) }.must_raise(Change::Exceptions::ChangeException)
+    end
+
   end
 
   describe '#final_url' do


### PR DESCRIPTION
When the Change.org API returns a 500, it the 500 html page leading to this problem 
![change-error](https://f.cloud.github.com/assets/396486/219428/78a81d52-852e-11e2-9b6b-727ab8c66357.png)
